### PR TITLE
Fix backoff

### DIFF
--- a/Core/Commands/commands.go
+++ b/Core/Commands/commands.go
@@ -59,7 +59,6 @@ func processImageReply(image []byte, err error, s *discordgo.Session, i *discord
 	if err != nil {
 
 		err_response := "An error occurred: " + err.Error()
-		log.Printf("Error during image api:\n %s", err_response)
 		response_edit = &discordgo.WebhookEdit{
 			Content: &err_response,
 		}

--- a/Core/Services/Database/redis.go
+++ b/Core/Services/Database/redis.go
@@ -45,7 +45,6 @@ func (r *Redis) Delete(item string) error {
 
 func (r *Redis) FetchRandom(n int) ([]string, error) {
 
-
 	values, err := r.rdb.SRandMemberN(r.ctx, r.set_name, int64(n)).Result()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR improved the image api wrapper:
- return API error on a bad request (or error)
- stop backoff if the response is 400 ( and return api error)